### PR TITLE
Fix nested <a> elements in category list

### DIFF
--- a/src/components/homepage/categoryList.tsx
+++ b/src/components/homepage/categoryList.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import MainShowcaseImage from '../../app/images/mianshowcase.jpg';
 
-const categroyItems = [
+const categoryItems = [
   {
     title: 'Desk and Office',
     description: 'Work from home accessories',
@@ -54,17 +54,15 @@ const HPCategoryList = () => {
         <div className="mx-auto max-w-2xl py-16 sm:py-24 lg:max-w-none lg:py-32">
           <h2 className="text-2xl font-bold text-gray-900">Collections</h2>
           <div className="mt-6 space-y-12 lg:grid lg:grid-cols-3 lg:gap-x-6 lg:space-y-0">
-            {categroyItems.map((item, index) => (
+            {categoryItems.map((item, index) => (
               <div key={index} className="group relative">
                 <Link href={item.link}>
                   <div className="relative h-80 w-full overflow-hidden rounded-lg bg-white sm:aspect-h-1 sm:aspect-w-2 lg:aspect-h-1 lg:aspect-w-1 group-hover:opacity-75 sm:h-64">
                     <Image src={item.image} alt={item.alt} className="h-full w-full object-cover object-center" />
                   </div>
                   <h3 className="mt-6 text-sm text-gray-500">
-                    <a href={item.link}>
-                      <span className="absolute inset-0"></span>
-                      {item.title}
-                    </a>
+                    <span className="absolute inset-0" />
+                    {item.title}
                   </h3>
                   <p className="text-base font-semibold text-gray-900">{item.description}</p>
                 </Link>


### PR DESCRIPTION
## Summary
- cleanup HPCategoryList to avoid anchor nesting
- rename `categroyItems` to `categoryItems`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfb56f968832297d12e95f778faaf